### PR TITLE
Add trailing "ends here" line for package.el compatibility

### DIFF
--- a/actionscript-mode.el
+++ b/actionscript-mode.el
@@ -572,3 +572,4 @@ whitespace. Keep point at same relative point in the line."
 		(message "actionscript-mode reloaded.")))
 
 (define-key global-map [f5] 'reload-actionscript-mode)
+;;; actionscript-mode.el ends here


### PR DESCRIPTION
This commit allows the library to be parsed by `package-buffer-info`, and hence installable from the package built automatically by [MELPA](http://melpa.milkbox.net/)
