### PR TITLE
Set auto-mode-alist with autoload-cookie

### DIFF
--- a/actionscript-mode.el
+++ b/actionscript-mode.el
@@ -560,6 +560,9 @@ whitespace. Keep point at same relative point in the line."
 ;; We need to make an adjustment to hideshow to work properly with AS syntax.
 (add-to-list 'hs-special-modes-alist '(actionscript-mode "{" "}" "/[*/]" nil hs-c-like-adjust-block-beginning))
 
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.as$" . actionscript-mode))
+
 (provide 'actionscript-mode)
 
 ;; For testing


### PR DESCRIPTION
This commit ensures that users who have installed `actionscript-mode` with `package.el` will be able to automatically turn on `actionscript-mode` when visiting a `as`  file without explicitly requiring the library first. For details, See [Packaging-Basics](http://www.gnu.org/software/emacs/manual/html_node/elisp/Packaging-Basics.html).
