### PR TITLE
Load cl.el only compile time

### DIFF
--- a/actionscript-mode.el
+++ b/actionscript-mode.el
@@ -46,9 +46,9 @@
 
 ;;; Code:
 
-(require 'cl)
 (require 'font-lock)
 (eval-when-compile
+  (require 'cl)
   (require 'regexp-opt))
 
 (defconst actionscript-mode-version "7.2.2"


### PR DESCRIPTION
Because this package uses only cl macros. And this fixes
byte-compile warning.

```
actionscript-mode.el:49:1:Warning: cl package required at runtime
```