### PR TITLE
Don't bind user-reserved keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ http://www.emacswiki.org/emacs/ActionScriptMode
 Insert a print statement immediately after the nearest function
 definition before point.
 
-This is bound to `F5`.
+This is unbound by default.  You might want to bind to `F5`.
 
 ### as-insert-trace
 

--- a/actionscript-config.el
+++ b/actionscript-config.el
@@ -143,5 +143,4 @@ with a directory named 'as' from which it builds package names."
     (visit-tags-table (concat default-directory "/TAGS"))))
 
 ;; Keybindings
-(define-key actionscript-mode-map [f5] 'as-print-func-info)
 (define-key actionscript-mode-map "\C-c\C-t" 'as-insert-trace)

--- a/actionscript-mode.el
+++ b/actionscript-mode.el
@@ -575,5 +575,4 @@ whitespace. Keep point at same relative point in the line."
 		(actionscript-mode)
 		(message "actionscript-mode reloaded.")))
 
-(define-key global-map [f5] 'reload-actionscript-mode)
 ;;; actionscript-mode.el ends here


### PR DESCRIPTION
See `(info "(elisp) Key Binding Conventions")`, particularly the following tip:

> Function keys <F5> through <F9> without modifier keys are also reserved for users to define.

The current behavior is annoying as it rebinds my own F5 key binding. If you wish, I can remove the testing function previously bound to F5 as well, it doesn't seem like the thing you'd want to check in.

If you're interested, I can submit more MRs for bringing this mode into shape.